### PR TITLE
Refactor Formik to support optional sections

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -80,5 +80,9 @@
         "extensions": [".js", ".jsx", ".ts", ".tsx"]
       }
     }
+  },
+  "globals": {
+    "React": "readonly",
+    "JSX": "readonly"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import './globals.css';
 import NavBarFunc from './NavBarFunc';
 import VolunteerFormComponent from './components/volunteer/VolunteerFormComponent';
 import BeneficiariesFormComponent from './components/beneficiaries/BeneficiariesFormComponent';
-import FormSubmitted from './components/formik/FormSuccess';
+import FormSubmitComponent from './components/formik/FormSuccess';
 // import ProgramRequestSelection from './components/request/RequestProgramSelection';
 
 function App() {
@@ -38,24 +38,29 @@ function App() {
           />
           {/* <Route exact path="/request/list" component={ProgramRequestSelection} /> */}
           {/* <Route exact path="/request/list" component={RequestCreateComponent} /> */}
+          {/* <Route exact path="/request/create" component={RequestCreateComponent} /> */}
+          <Route exact path="/program/list" component={ProgramListComponent} />
+          <Route exact path="/stage/list" component={StageListComponent} />
           <Route
             exact
             path="/beneficiaries/form"
             component={BeneficiariesFormComponent}
           />
-          {/* <Route exact path="/request/create" component={RequestCreateComponent} /> */}
-          <Route exact path="/program/list" component={ProgramListComponent} />
-          <Route exact path="/stage/list" component={StageListComponent} />
-          {/* <Route exact path="/beneficiaries/list" component={BeneficiariesComponent} /> */}
+          <Route
+            exact
+            path="/beneficiaries/form/submitted"
+            component={FormSubmitComponent}
+          />
           <Route
             exact
             path="/volunteers/form"
             component={VolunteerFormComponent}
           />
-          <Route exact path="/submitted">
-            {' '}
-            <FormSubmitted />{' '}
-          </Route>
+          <Route
+            exact
+            path="/volunteers/form/submitted"
+            component={FormSubmitComponent}
+          />
           <Route component={HomeComponent} />
         </Switch>
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,14 +38,18 @@ function App() {
           />
           {/* <Route exact path="/request/list" component={ProgramRequestSelection} /> */}
           {/* <Route exact path="/request/list" component={RequestCreateComponent} /> */}
-          <Route exact path="/request/list" component={BeneficiariesFormComponent} />
+          <Route
+            exact
+            path="/beneficiaries/form"
+            component={BeneficiariesFormComponent}
+          />
           {/* <Route exact path="/request/create" component={RequestCreateComponent} /> */}
           <Route exact path="/program/list" component={ProgramListComponent} />
           <Route exact path="/stage/list" component={StageListComponent} />
           {/* <Route exact path="/beneficiaries/list" component={BeneficiariesComponent} /> */}
           <Route
             exact
-            path="/volunteer/list"
+            path="/volunteers/form"
             component={VolunteerFormComponent}
           />
           <Route exact path="/submitted">

--- a/src/NavBarFunc.tsx
+++ b/src/NavBarFunc.tsx
@@ -29,9 +29,9 @@ export default function NavBarFunc() {
   ];
   const mainMenuOptions = [
     { link: '/request/list', menuText: 'Requests', implemented: true },
-    { link: '/volunteer/list', menuText: 'Volunteers', implemented: false },
+    { link: '/volunteers/form', menuText: 'Volunteers', implemented: false },
     {
-      link: '/beneficiaries/list',
+      link: '/beneficiaries/form',
       menuText: 'Beneficiaries',
       implemented: false,
     },

--- a/src/components/beneficiaries/BeneficiariesFormComponent.tsx
+++ b/src/components/beneficiaries/BeneficiariesFormComponent.tsx
@@ -3,7 +3,7 @@ import {
   BENEFICIARIES_FORM,
   BENEFICIARIES_INITIAL_VALUES,
   BENEFICIARIES_SCHEMA,
-} from './beneficiariesFormData';
+} from './BeneficiariesFormData';
 import FormikComponent from '../formik/FormikComponent';
 
 function BeneficiariesFormComponent() {
@@ -18,11 +18,11 @@ function BeneficiariesFormComponent() {
     schema: BENEFICIARIES_SCHEMA,
   });
 
-  const { form: formSections, initialValues, schema } = getData();
+  const { form, initialValues, schema } = getData();
 
   return (
     <FormikComponent
-      formSections={formSections}
+      formFields={form}
       initialValues={initialValues}
       schema={schema}
     />

--- a/src/components/beneficiaries/BeneficiariesFormComponent.tsx
+++ b/src/components/beneficiaries/BeneficiariesFormComponent.tsx
@@ -21,11 +21,18 @@ function BeneficiariesFormComponent() {
   const { form, initialValues, schema } = getData();
 
   return (
-    <FormikComponent
-      formFields={form}
-      initialValues={initialValues}
-      schema={schema}
-    />
+    <>
+      <h1>Beneficiaries Form</h1>
+      <p>
+        Please fill out your information so we can match you with a volunteer to
+        fulfill your request.
+      </p>
+      <FormikComponent
+        formFields={form}
+        initialValues={initialValues}
+        schema={schema}
+      />
+    </>
   );
 }
 

--- a/src/components/beneficiaries/beneficiariesFormData.ts
+++ b/src/components/beneficiaries/beneficiariesFormData.ts
@@ -173,10 +173,6 @@ export const BENEFICIARIES_FORM: FormField[] = [
 
 export const BENEFICIARIES_SCHEMA = Yup.object().shape({
   name: Yup.string().required('Please enter your name'),
-  email: Yup.string()
-    .required('Please enter your email')
-    .email('Please enter a valid email'),
-  phone: Yup.string(),
   address: Yup.string(),
   postal: Yup.string()
     .required('Please enter a Postal code or Zip code')
@@ -184,26 +180,30 @@ export const BENEFICIARIES_SCHEMA = Yup.object().shape({
       /[a-zA-Z][0-9][a-zA-Z] ?[a-zA-Z][0-9][a-zA-Z]|([a-zA-Z]{2})?[0-9]{5}/,
       'Please enter a valid Postal code or Zip code',
     ),
+  email: Yup.string()
+    .required('Please enter your email')
+    .email('Please enter a valid email'),
+  phone: Yup.string(),
   dob: Yup.string().required('Please select your date of birth'),
-  covid: Yup.string().required('Please select an option'),
-  helpType: Yup.array().min(1, 'Please select at least one option'),
   weakImuneSystem: Yup.string().required('Please select an option'),
   chronicIllness: Yup.string().required('Please select an option'),
   livingAlone: Yup.string().required('Please select an option'),
   sickWithCovid: Yup.string().required('Please select an option'),
+  helpType: Yup.array().min(1, 'Please select at least one option'),
+  grocery: Yup.array().min(0),
 });
 
 export const BENEFICIARIES_INITIAL_VALUES = {
   name: '',
-  email: '',
-  phone: '',
   address: '',
   postal: '',
+  email: '',
+  phone: '',
   dob: '',
-  covid: '',
-  helpType: [],
   weakImuneSystem: '',
   chronicIllness: '',
   livingAlone: '',
   sickWithCovid: '',
+  helpType: [],
+  grocery: [],
 };

--- a/src/components/beneficiaries/beneficiariesFormData.ts
+++ b/src/components/beneficiaries/beneficiariesFormData.ts
@@ -1,5 +1,5 @@
 import * as Yup from 'yup';
-import { FieldOption, FormField, FormSection } from '../formik/types';
+import { FieldOption, FormField } from '../formik/types';
 
 const YES_NO_OPTIONS: FieldOption[] = [
   {
@@ -12,19 +12,21 @@ const YES_NO_OPTIONS: FieldOption[] = [
   },
 ];
 
-const EXAMPLE_PERSONAL: FormField[] = [
+export const BENEFICIARIES_FORM: FormField[] = [
   {
     type: 'text',
     name: 'name',
     label: 'Full Name',
     required: true,
     placeholder: 'Full Name',
+    sectionTitle: 'Personal Information',
   },
   {
     type: 'text',
     name: 'address',
     label: 'Address',
     placeholder: 'Address',
+    sectionTitle: 'Personal Information',
   },
   {
     type: 'text',
@@ -33,6 +35,7 @@ const EXAMPLE_PERSONAL: FormField[] = [
     required: true,
     placeholder: 'Postal Code',
     shortStyle: true,
+    sectionTitle: 'Personal Information',
   },
   {
     type: 'email',
@@ -40,12 +43,14 @@ const EXAMPLE_PERSONAL: FormField[] = [
     label: 'Email',
     required: true,
     placeholder: 'Email',
+    sectionTitle: 'Personal Information',
   },
   {
     type: 'tel',
     name: 'phone',
     label: 'Phone Number',
     placeholder: 'Phone Number',
+    sectionTitle: 'Personal Information',
   },
 
   {
@@ -53,6 +58,7 @@ const EXAMPLE_PERSONAL: FormField[] = [
     name: 'dob',
     label: 'Date of birth',
     required: true,
+    sectionTitle: 'Personal Information',
   },
   {
     type: 'select',
@@ -64,16 +70,15 @@ const EXAMPLE_PERSONAL: FormField[] = [
       { label: 'Place 2', value: 'Place Two' },
       { label: 'Place 3', value: 'Place Three' },
     ],
+    sectionTitle: 'Personal Information',
   },
-];
-
-const EXAMPLE_HEALTH: FormField[] = [
   {
     type: 'radio',
     name: 'weakImuneSystem',
     label: 'Do you have a weakened immune system?',
     required: true,
     options: YES_NO_OPTIONS,
+    sectionTitle: 'Health Information',
   },
   {
     type: 'radio',
@@ -81,6 +86,7 @@ const EXAMPLE_HEALTH: FormField[] = [
     label: 'Do you have a chronic illness?',
     required: true,
     options: YES_NO_OPTIONS,
+    sectionTitle: 'Health Information',
   },
   {
     type: 'radio',
@@ -88,6 +94,7 @@ const EXAMPLE_HEALTH: FormField[] = [
     label: 'Do you live alone with a limited support network?',
     required: true,
     options: YES_NO_OPTIONS,
+    sectionTitle: 'Health Information',
   },
   {
     type: 'radio',
@@ -95,6 +102,7 @@ const EXAMPLE_HEALTH: FormField[] = [
     label: 'Are you currently sick or experiencing Covid-19 symptoms?',
     required: true,
     options: YES_NO_OPTIONS,
+    sectionTitle: 'Health Information',
   },
   {
     type: 'text',
@@ -102,10 +110,8 @@ const EXAMPLE_HEALTH: FormField[] = [
     label:
       'If you would like to explain your situation, or would like to share more details, please write it here.',
     placeholder: 'Miscellaneous',
+    sectionTitle: 'Health Information',
   },
-];
-
-const EXAMPLE_PROGRAM_DETAILS: FormField[] = [
   {
     type: 'checkbox',
     name: 'helpType',
@@ -125,6 +131,7 @@ const EXAMPLE_PROGRAM_DETAILS: FormField[] = [
         value: 'grocery',
       },
     ],
+    sectionTitle: 'Program Details',
   },
   {
     type: 'checkbox',
@@ -160,24 +167,7 @@ const EXAMPLE_PROGRAM_DETAILS: FormField[] = [
         value: 'yougurt',
       },
     ],
-  },
-];
-
-export const BENEFICIARIES_FORM: FormSection[] = [
-  {
-    id: 'personal-info',
-    label: 'Personal Details',
-    formFields: EXAMPLE_PERSONAL,
-  },
-  {
-    id: 'health-info',
-    label: 'Health Details',
-    formFields: EXAMPLE_HEALTH,
-  },
-  {
-    id: 'program-info',
-    label: 'Program Details',
-    formFields: EXAMPLE_PROGRAM_DETAILS,
+    sectionTitle: 'Program Details',
   },
 ];
 
@@ -194,7 +184,6 @@ export const BENEFICIARIES_SCHEMA = Yup.object().shape({
       /[a-zA-Z][0-9][a-zA-Z] ?[a-zA-Z][0-9][a-zA-Z]|([a-zA-Z]{2})?[0-9]{5}/,
       'Please enter a valid Postal code or Zip code',
     ),
-
   dob: Yup.string().required('Please select your date of birth'),
   covid: Yup.string().required('Please select an option'),
   helpType: Yup.array().min(1, 'Please select at least one option'),

--- a/src/components/formik/FormSuccess.tsx
+++ b/src/components/formik/FormSuccess.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Style from './FormSuccess.module.css';
 
-function FormSubmitted() {
+function FormSubmitComponent() {
   return (
     <div className={Style.body}>
       <div className={Style.p}>
@@ -11,11 +11,11 @@ function FormSubmitted() {
           </div>
           <h1>Success</h1>
           <p>Your form has been submitted successfully.</p>
-          <p>We wo;; be in touch shortly!</p>
+          <p>We will be in touch shortly!</p>
         </div>
       </div>
     </div>
   );
 }
 
-export default FormSubmitted;
+export default FormSubmitComponent;

--- a/src/components/formik/FormikComponent.tsx
+++ b/src/components/formik/FormikComponent.tsx
@@ -27,7 +27,7 @@ function FormikComponent(props: Props) {
         validationSchema={schema}
         onSubmit={(values, { setSubmitting }) => {
           console.log(values);
-          history.push('/submitted');
+          history.push(`${history.location.pathname}/submitted`);
           setSubmitting(false);
         }}
       >

--- a/src/components/formik/FormikComponent.tsx
+++ b/src/components/formik/FormikComponent.tsx
@@ -6,17 +6,19 @@ import { useHistory } from 'react-router-dom';
 import { Formik, Form } from 'formik';
 import Style from './formikStyle.module.css';
 import FieldComponent from './fieldComponents/FieldComponent';
-import { FormSection } from './types';
+import { FormField } from './types';
 
 interface Props {
-  formSections: FormSection[];
+  formFields: FormField[];
   initialValues: Record<string, unknown>;
   schema: Yup.ObjectSchema<AnyObject>;
 }
 
 function FormikComponent(props: Props) {
-  const { formSections, initialValues, schema } = props;
+  const { formFields, initialValues, schema } = props;
   const history = useHistory();
+
+  let previousSection: string = '';
 
   return (
     <div className={Style.formikForm}>
@@ -30,16 +32,25 @@ function FormikComponent(props: Props) {
         }}
       >
         <Form>
-          {formSections.map((formSection) => (
-            <div key={formSection.id} className={Style.formField}>
-              <h2 className={Style.formFieldHeader}>{formSection.label}</h2>
-              <div>
-                {formSection.formFields.map((formField) => (
+          {formFields.map((formField) => {
+            if (
+              formField.sectionTitle
+              && formField.sectionTitle !== previousSection
+            ) {
+              previousSection = formField.sectionTitle;
+              return (
+                <>
+                  <h2 className={Style.formFieldHeader}>
+                    {formField.sectionTitle}
+                  </h2>
                   <FieldComponent key={formField.name} formField={formField} />
-                ))}
-              </div>
-            </div>
-          ))}
+                </>
+              );
+            }
+            return (
+              <FieldComponent key={formField.name} formField={formField} />
+            );
+          })}
           <button type="submit" className={Style.submit}>
             Submit
           </button>

--- a/src/components/formik/fieldComponents/FieldComponent.tsx
+++ b/src/components/formik/fieldComponents/FieldComponent.tsx
@@ -15,15 +15,11 @@ interface Props {
   formField: FormField;
 }
 
-function FieldComponentWrapper(component: JSX.Element | undefined) {
+function FieldComponentWrapper(component?: JSX.Element) {
   if (!component) {
     return null;
   }
-  return (
-    <div className={Style.formField}>
-      {component}
-    </div>
-  );
+  return <div className={Style.formField}>{component}</div>;
 }
 
 function FieldComponent(props: Props) {
@@ -35,14 +31,13 @@ function FieldComponent(props: Props) {
     component = <TextFieldComponent formField={formField} />;
   } else if (checkRadioFieldSet.has(formField.type)) {
     component = <CheckRadioFieldComponent formField={formField} />;
-  } else if (selectFieldSet.has(formField.type)) { return FieldComponentWrapper(component); }
-  if (selectFieldSet.has(formField.type)) {
-    return <SelectComponent formField={formField} />;
+  } else if (selectFieldSet.has(formField.type)) {
+    return FieldComponentWrapper(component);
   }
   if (selectFieldSet.has(formField.type)) {
-    return <SelectComponent formField={formField} />;
+    component = <SelectComponent formField={formField} />;
   }
-  return null;
+  return FieldComponentWrapper(component);
 }
 
 export default FieldComponent;

--- a/src/components/formik/fieldComponents/FieldComponent.tsx
+++ b/src/components/formik/fieldComponents/FieldComponent.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Style from '../formikStyle.module.css';
 import {
   textFieldSet,
   checkRadioFieldSet,
@@ -14,14 +15,29 @@ interface Props {
   formField: FormField;
 }
 
+function FieldComponentWrapper(component: JSX.Element | undefined) {
+  if (!component) {
+    return null;
+  }
+  return (
+    <div className={Style.formField}>
+      {component}
+    </div>
+  );
+}
+
 function FieldComponent(props: Props) {
   const { formField } = props;
 
+  let component: JSX.Element | undefined;
+
   if (textFieldSet.has(formField.type)) {
-    return <TextFieldComponent formField={formField} />;
-  }
-  if (checkRadioFieldSet.has(formField.type)) {
-    return <CheckRadioFieldComponent formField={formField} />;
+    component = <TextFieldComponent formField={formField} />;
+  } else if (checkRadioFieldSet.has(formField.type)) {
+    component = <CheckRadioFieldComponent formField={formField} />;
+  } else if (selectFieldSet.has(formField.type)) { return FieldComponentWrapper(component); }
+  if (selectFieldSet.has(formField.type)) {
+    return <SelectComponent formField={formField} />;
   }
   if (selectFieldSet.has(formField.type)) {
     return <SelectComponent formField={formField} />;

--- a/src/components/formik/types.ts
+++ b/src/components/formik/types.ts
@@ -37,10 +37,5 @@ export type FormField = {
   placeholder?: string | number;
   required?: boolean;
   shortStyle?: boolean;
+  sectionTitle?: string;
 };
-
-export interface FormSection {
-  id: string;
-  label: string;
-  formFields: FormField[];
-}

--- a/src/components/volunteer/VolunteerFormComponent.tsx
+++ b/src/components/volunteer/VolunteerFormComponent.tsx
@@ -17,7 +17,7 @@ function VolunteerFormComponent() {
     schema: VOLUNTEER_SCHEMA,
   });
 
-  const { form: formSections, initialValues, schema } = getData();
+  const { form, initialValues, schema } = getData();
 
   return (
     <>
@@ -27,7 +27,7 @@ function VolunteerFormComponent() {
         volunteer form so we can start matching you with tasks.
       </p>
       <FormikComponent
-        formSections={formSections}
+        formFields={form}
         initialValues={initialValues}
         schema={schema}
       />

--- a/src/components/volunteer/VolunteerFormData.tsx
+++ b/src/components/volunteer/VolunteerFormData.tsx
@@ -1,5 +1,5 @@
 import * as Yup from 'yup';
-import { FieldOption, FormField, FormSection } from '../formik/types';
+import { FieldOption, FormField } from '../formik/types';
 
 const YES_NO_OPTIONS: FieldOption[] = [
   {
@@ -12,13 +12,14 @@ const YES_NO_OPTIONS: FieldOption[] = [
   },
 ];
 
-const EXAMPLE_PERSONAL: FormField[] = [
+export const VOLUNTEER_FORM: FormField[] = [
   {
     type: 'text',
     name: 'name',
     label: 'Full Name',
     required: true,
     placeholder: 'Full Name',
+    sectionTitle: 'Personal Information',
   },
   {
     type: 'email',
@@ -26,18 +27,21 @@ const EXAMPLE_PERSONAL: FormField[] = [
     label: 'Email',
     required: true,
     placeholder: 'Email',
+    sectionTitle: 'Personal Information',
   },
   {
     type: 'tel',
     name: 'phone',
     label: 'Phone Number',
     placeholder: 'Phone Number',
+    sectionTitle: 'Personal Information',
   },
   {
     type: 'text',
     name: 'address',
     label: 'Address',
     placeholder: 'Address',
+    sectionTitle: 'Personal Information',
   },
   {
     type: 'text',
@@ -46,6 +50,7 @@ const EXAMPLE_PERSONAL: FormField[] = [
     required: true,
     placeholder: 'Postal Code',
     shortStyle: true,
+    sectionTitle: 'Personal Information',
   },
   {
     type: 'checkbox',
@@ -61,10 +66,8 @@ const EXAMPLE_PERSONAL: FormField[] = [
         value: 'french',
       },
     ],
+    sectionTitle: 'Personal Information',
   },
-];
-
-const EXAMPLE_VOLUNTEERING: FormField[] = [
   {
     type: 'checkbox',
     name: 'offer',
@@ -92,6 +95,7 @@ const EXAMPLE_VOLUNTEERING: FormField[] = [
         value: 'tech',
       },
     ],
+    sectionTitle: 'Volunteering Information',
   },
   {
     type: 'number',
@@ -99,6 +103,7 @@ const EXAMPLE_VOLUNTEERING: FormField[] = [
     label: 'Time commitment per week (approximate):',
     placeholder: 'Hours',
     shortStyle: true,
+    sectionTitle: 'Volunteering Information',
   },
   {
     type: 'radio',
@@ -126,10 +131,8 @@ const EXAMPLE_VOLUNTEERING: FormField[] = [
         value: 'none',
       },
     ],
+    sectionTitle: 'Volunteering Information',
   },
-];
-
-const EXAMPLE_HEALTH: FormField[] = [
   {
     type: 'radio',
     name: 'covid',
@@ -137,6 +140,7 @@ const EXAMPLE_HEALTH: FormField[] = [
       'Are you currently sick with COVID-19 or experiencing any COVID-19 symptoms?',
     required: true,
     options: YES_NO_OPTIONS,
+    sectionTitle: 'Covid-19 Health Information',
   },
   {
     type: 'radio',
@@ -145,6 +149,7 @@ const EXAMPLE_HEALTH: FormField[] = [
       'Have you been in close contact with someone with COVID-19 or someone who may have COVID-19?',
     required: true,
     options: YES_NO_OPTIONS,
+    sectionTitle: 'Covid-19 Health Information',
   },
   {
     type: 'radio',
@@ -153,24 +158,7 @@ const EXAMPLE_HEALTH: FormField[] = [
       'Have you travelled abroad in the past two weeks or been in close contact with someone who has?',
     required: true,
     options: YES_NO_OPTIONS,
-  },
-];
-
-export const VOLUNTEER_FORM: FormSection[] = [
-  {
-    id: 'personal-info',
-    label: 'Personal Information',
-    formFields: EXAMPLE_PERSONAL,
-  },
-  {
-    id: 'volunteering-info',
-    label: 'Volunteering Information',
-    formFields: EXAMPLE_VOLUNTEERING,
-  },
-  {
-    id: 'health-info',
-    label: 'COVID-19 Health Information',
-    formFields: EXAMPLE_HEALTH,
+    sectionTitle: 'Covid-19 Health Information',
   },
 ];
 


### PR DESCRIPTION
- Refactored Formik to support optional sections. Sections are no longer nested, and sections should only be produced if there is a section title supplied. To create a new section supply a different section title than the previous section
- Fixed beneficiaries form to use the new optional sections data format. Fixed some problems with the initial values and the yup schema
- Changed the routes so they make more sense (e.g. beneficiaries form at `/beneficiaries/form` and submitted beneficiaries form at `/beneficiaries/form/submitted`)