### PR TITLE
Rename BeneficiariesForm to singular

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import StageListComponent from './components/stage/StageListComponent';
 import './globals.css';
 import NavBarFunc from './NavBarFunc';
 import VolunteerFormComponent from './components/volunteer/VolunteerFormComponent';
-import BeneficiariesFormComponent from './components/beneficiaries/BeneficiariesFormComponent';
+import BeneficiaryFormComponent from './components/beneficiary/BeneficiaryFormComponent';
 import FormSubmitComponent from './components/formik/FormSuccess';
 // import ProgramRequestSelection from './components/request/RequestProgramSelection';
 
@@ -44,7 +44,7 @@ function App() {
           <Route
             exact
             path="/beneficiaries/form"
-            component={BeneficiariesFormComponent}
+            component={BeneficiaryFormComponent}
           />
           <Route
             exact

--- a/src/components/beneficiary/BeneficiaryFormComponent.tsx
+++ b/src/components/beneficiary/BeneficiaryFormComponent.tsx
@@ -1,28 +1,28 @@
 import React from 'react';
 import {
-  BENEFICIARIES_FORM,
-  BENEFICIARIES_INITIAL_VALUES,
-  BENEFICIARIES_SCHEMA,
-} from './BeneficiariesFormData';
+  BENEFICIARY_FORM,
+  BENEFICIARY_INITIAL_VALUES,
+  BENEFICIARY_SCHEMA,
+} from './BeneficiaryFormData';
 import FormikComponent from '../formik/FormikComponent';
 
-function BeneficiariesFormComponent() {
+function BeneficiaryFormComponent() {
   /**
    * Gets the form field data from the back end
    * TODO: complete the function
    */
   const getData = () => ({
-    name: 'Beneficiaries form',
-    form: BENEFICIARIES_FORM,
-    initialValues: BENEFICIARIES_INITIAL_VALUES,
-    schema: BENEFICIARIES_SCHEMA,
+    name: 'Beneficiary Form',
+    form: BENEFICIARY_FORM,
+    initialValues: BENEFICIARY_INITIAL_VALUES,
+    schema: BENEFICIARY_SCHEMA,
   });
 
   const { form, initialValues, schema } = getData();
 
   return (
     <>
-      <h1>Beneficiaries Form</h1>
+      <h1>Beneficiary Form</h1>
       <p>
         Please fill out your information so we can match you with a volunteer to
         fulfill your request.
@@ -36,4 +36,4 @@ function BeneficiariesFormComponent() {
   );
 }
 
-export default BeneficiariesFormComponent;
+export default BeneficiaryFormComponent;

--- a/src/components/beneficiary/BeneficiaryFormData.ts
+++ b/src/components/beneficiary/BeneficiaryFormData.ts
@@ -12,7 +12,7 @@ const YES_NO_OPTIONS: FieldOption[] = [
   },
 ];
 
-export const BENEFICIARIES_FORM: FormField[] = [
+export const BENEFICIARY_FORM: FormField[] = [
   {
     type: 'text',
     name: 'name',
@@ -171,7 +171,7 @@ export const BENEFICIARIES_FORM: FormField[] = [
   },
 ];
 
-export const BENEFICIARIES_SCHEMA = Yup.object().shape({
+export const BENEFICIARY_SCHEMA = Yup.object().shape({
   name: Yup.string().required('Please enter your name'),
   address: Yup.string(),
   postal: Yup.string()
@@ -193,7 +193,7 @@ export const BENEFICIARIES_SCHEMA = Yup.object().shape({
   grocery: Yup.array().min(0),
 });
 
-export const BENEFICIARIES_INITIAL_VALUES = {
+export const BENEFICIARY_INITIAL_VALUES = {
   name: '',
   address: '',
   postal: '',


### PR DESCRIPTION
Originally renamed `beneficiariesFormData.ts` to `BeneficiariesFormData.ts` to be consistent with capitalization used in volunteer form, but Git did not capitalize the filename (seems to not care about the case). So, in our repo the file was still `beneficiariesFormData.ts` causing the code to not compile. I decided to just rename to `Beneficiary` since `VolunteerFormComponent` is not plural.