### PR TITLE
Fix ProgramService crash

### DIFF
--- a/src/services/ProgramService.ts
+++ b/src/services/ProgramService.ts
@@ -19,7 +19,7 @@ class ProgramService {
     // const response = await fetch('http://localhost:8080/program/list'); // returns promise to get Programs
     // const json = await response.json();
     // return json.data;
-    const programsFromStorage = localStorage.getItem('programs') || '';
+    const programsFromStorage = localStorage.getItem('programs') || '[]';
     const programsJson = JSON.parse(programsFromStorage);
     return programsJson;
   }


### PR DESCRIPTION
Bug caused Programs page to crash upon opening. Changed `programsFromStorage` to be `'[]'` instead of `''` if no programs in local storage.